### PR TITLE
Fix comma-dangle issue when inserting template into string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = {
       // Insert template into script
       if (template.length > 0) {
         var e = script.lastIndexOf('}');
-        script = script.slice(0, e).replace(/,\s+$/g, '') + ', template: ' + JSON.stringify(template.trim()) + script.slice(e);
+        script = script.slice(0, e).replace(/,\s*$/g, '') + ', template: ' + JSON.stringify(template.trim()) + script.slice(e);
       } else {
         // skip
       }

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = {
       // Insert template into script
       if (template.length > 0) {
         var e = script.lastIndexOf('}');
-        script = script.slice(0, e) + ', template: ' + JSON.stringify(template.trim()) + script.slice(e);
+        script = script.slice(0, e).replace(/,\s+$/g, '') + ', template: ' + JSON.stringify(template.trim()) + script.slice(e);
       } else {
         // skip
       }


### PR DESCRIPTION
Here is an example where vue-jest currently fails collecting coverage due to the comma-dangle:

```
<template>
</template>

<script>
  export default {
    data () {
      return {
        foo: 'bar'
      }
    },
  }
</script>

<style>
</style>
```

This PR fixes the issue.